### PR TITLE
fix: do not throw if last claim is zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -368,12 +368,13 @@ class Plugin extends BtpPlugin {
     // but then the latency would effectively double.
 
     debug('given last claim of', this._lastClaim)
-    const dropAmount = util.xrpToDrops(this.baseToXrp(this._lastClaim.amount))
-    const encodedClaim = util.encodeClaim(dropAmount, this._channel)
 
     // If they say we haven't sent them anything yet, it doesn't matter
     // whether they possess a valid claim to say that.
-    if (this.baseToXrp(this._lastClaim.amount) !== this._channelDetails.balance) {
+    if (!new BigNumber(this.baseToXrp(this._lastClaim.amount)).isEqualTo(this._channelDetails.balance)) {
+      const dropAmount = util.xrpToDrops(this.baseToXrp(this._lastClaim.amount))
+      const encodedClaim = util.encodeClaim(dropAmount, this._channel)
+
       let isValid = false
       try {
         isValid = nacl.sign.detached.verify(

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -89,14 +89,24 @@ describe('pluginSpec', () => {
         }
       })
 
+      it('should not throw if last claim is zero', async function () {
+        const encodeSpy = this.sinon.spy(util, 'encodeClaim')
+        this.plugin._lastClaim.amount = '0'
+        this.plugin._channelDetails.balance = '0'
+        this.sinon.stub(this.plugin, '_call').resolves(null)
+
+        await this.plugin.sendMoney(100)
+
+        assert.deepEqual(encodeSpy.getCall(0).args, [ '1', 'abcdef' ])
+      })
+
       it('should round high-scale amount up to next drop', async function () {
         const encodeSpy = this.sinon.spy(util, 'encodeClaim')
         this.sinon.stub(this.plugin, '_call').resolves(null)
 
         await this.plugin.sendMoney(100)
 
-        assert.deepEqual(encodeSpy.getCall(0).args, [ '1', 'abcdef' ])
-        assert.deepEqual(encodeSpy.getCall(1).args, [ '2', 'abcdef' ])
+        assert.deepEqual(encodeSpy.getCall(0).args, [ '2', 'abcdef' ])
       })
 
       it('should keep error under a drop even on repeated roundings', async function () {
@@ -111,10 +121,8 @@ describe('pluginSpec', () => {
 
         await this.plugin.sendMoney(100)
 
-        assert.deepEqual(encodeSpy.getCall(0).args, [ '1', 'abcdef' ])
+        assert.deepEqual(encodeSpy.getCall(0).args, [ '2', 'abcdef' ])
         assert.deepEqual(encodeSpy.getCall(1).args, [ '2', 'abcdef' ])
-        assert.deepEqual(encodeSpy.getCall(2).args, [ '2', 'abcdef' ])
-        assert.deepEqual(encodeSpy.getCall(3).args, [ '2', 'abcdef' ])
       })
 
       it('should handle a claim', async function () {


### PR DESCRIPTION
Won't encode the last claim signature if it matches the channel balance, meaning that a last claim of zero won't cause the plugin to throw.

Closes https://github.com/interledgerjs/moneyd-xrp/issues/22