### PR TITLE
Fix: catch errors in auto claim interval

### DIFF
--- a/index.js
+++ b/index.js
@@ -283,7 +283,11 @@ class Plugin extends BtpPlugin {
       this._log.trace('setting claim interval on channel.')
       this._lastClaimedAmount = new BigNumber(this.xrpToBase(this._paychan.balance))
       this._claimIntervalId = setInterval(async () => {
-        await this._autoClaim()
+        try {
+          await this._autoClaim()
+        } catch (e) {
+          this._log.error('error during auto-claim. error=' + e.stack)
+        }
       }, this._claimInterval)
 
       this._log.trace('loaded best claim (on clientChannel) of', this._bestClaim)


### PR DESCRIPTION
Turns out that when the callback in setInterval throws an error, it cancels the interval. This could put asym-clients into a bad state where they're no longer submitting claims automatically. Some T04s are caused as a result of this issue, when the asym server can't see the best claim it signed by looking at the ledger.

Given that the callback is an async function, I haven't yet identified where the error could be thrown.