### PR TITLE
avoid to topup negative amount with "moneyd xrp:topup --amount -10000…

### DIFF
--- a/index.js
+++ b/index.js
@@ -403,6 +403,10 @@ class Plugin extends BtpPlugin {
   }
 
   async sendMoney (transferAmount) {
+    if (new BigNumber(transferAmount).isLessThan(0)) {
+      throw new Error('Cannot make a new claim which is lower than the last claim.')
+    }
+
     if (new BigNumber(transferAmount).isEqualTo(0)) {
       return
     }


### PR DESCRIPTION
avoid to topup negative amount with "moneyd xrp:topup --amount -10000 --testnet"

## Before change, doesn't check and submit directly, get timeout error
>moneyd xrp:topup --amount -100000 --testnet

fatal: Error: 1522484872 timed out
    at Timeout.setTimeout (C:\Users\xxxxxx\AppData\Roaming\npm\node_modules\moneyd-uplink-xrp\node_modules\ilp-plugin-btp\src\index.ts:459:7)
    at ontimeout (timers.js:498:11)
    at tryOnTimeout (timers.js:323:5)
    at Timer.listOnTimeout (timers.js:290:5)

## After change, return directly with a proper error
>moneyd xrp:topup --amount -100000 --testnet

fatal: Error: Cannot make a new claim which is lower than the last claim.
    at Plugin.sendMoney (C:\Users\xxxxxx\AppData\Roaming\npm\node_modules\moneyd-uplink-xrp\node_modules\ilp-plugin-xrp-asym-client\index.js:402:13)
    at XrpUplink.topup (C:\Users\xxxxxx\AppData\Roaming\npm\node_modules\moneyd-uplink-xrp\index.js:210:18)
    at <anonymous>